### PR TITLE
Fix indexing on clock emoji list

### DIFF
--- a/dwms.go
+++ b/dwms.go
@@ -139,7 +139,7 @@ func timeFmt(t time.Time, dateFormat string, timeFormat string) []string {
 	// get clock row
 	hour := offsetTime.Hour() % 12
 	// get clock col
-	halfHour := (offsetTime.Minute() + 1) / 30
+	halfHour := offsetTime.Minute() / 30
 	clockEmojis := [24]string{
 		"🕛", "🕧",
 		"🕐", "🕜",


### PR DESCRIPTION
At 11:44, the offset time had a minute value of 59, so when the integer 1 was added to that, it resulted in 60, which is not a valid minute value. The clock emoji list was being queried at index 24, which caused a panic.